### PR TITLE
Implement device selection and realistic sizing

### DIFF
--- a/src/data/deviceTypes.ts
+++ b/src/data/deviceTypes.ts
@@ -1,0 +1,19 @@
+import { calculateDevicePixels } from '../utils/deviceCalculations';
+
+export interface DeviceType {
+  id: string;
+  name: string;
+  diagonalInch: number;
+  aspectRatio: number; // width / height
+  ppi: number;
+}
+
+export function getDevicePixels(device: DeviceType) {
+  return calculateDevicePixels(device.diagonalInch, device.aspectRatio, device.ppi);
+}
+
+export const deviceTypes: DeviceType[] = [
+  { id: 'default', name: 'Default Phone', diagonalInch: 6, aspectRatio: 9 / 16, ppi: 300 },
+  { id: 'iphone-x', name: 'iPhone X', diagonalInch: 5.8, aspectRatio: 9 / 19.5, ppi: 458 },
+  { id: 'samsung-tab', name: 'Samsung Tablet', diagonalInch: 10.1, aspectRatio: 16 / 10, ppi: 160 },
+];

--- a/src/features/device/components/DeviceArea.tsx
+++ b/src/features/device/components/DeviceArea.tsx
@@ -3,24 +3,28 @@ import DeviceHeader from "./DeviceHeader";
 import DeviceScreen from "./DeviceScreen";
 import PhysicallyButtons from "./PhysicallyButtons";
 import DeviceActionButtonGroup from "./DeviceActionButtonGroup";
+import { DeviceType, getDevicePixels } from "../../../data/deviceTypes";
 
 interface DeviceAreaProps {
+  device: DeviceType;
   isRotated: boolean;
   onRotate: () => void;
 }
 
-const DeviceArea: React.FC<DeviceAreaProps> = ({ isRotated, onRotate }) => {
+const DeviceArea: React.FC<DeviceAreaProps> = ({ device, isRotated, onRotate }) => {
+  const { widthPx, heightPx } = getDevicePixels(device);
+  const screenWidth = isRotated ? heightPx : widthPx;
+  const screenHeight = isRotated ? widthPx : heightPx;
 
   return (
-    <section className={`flex-1 flex flex-col gap-4 w-full ml-0 mx-auto ${isRotated ? 'max-w-[70vw]' : 'max-w-[40vw]'}`}>
-      <DeviceHeader />
-      <div className="flex flex-col lg:flex-row gap-2 lg:gap-4 flex-1 min-h-[50vh] lg:min-h-[25vh] h-full items-stretch">
-        <div className={`flex flex-col items-center w-full h-full min-w-0 ${isRotated ? 'aspect-[16/9] min-w-[30vw] max-w-[40vw] h-auto' : 'aspect-[9/16] min-h-[40vh] max-h-[70vh]'}`}>
-          <DeviceScreen isRotated={isRotated} />
-          <PhysicallyButtons isRotated={isRotated} />
+    <section className="flex-1 flex flex-col gap-4 mx-auto" style={{ width: screenWidth }}>
+      <DeviceHeader device={device} />
+      <div className="flex flex-col lg:flex-row gap-2 lg:gap-4 flex-1 items-stretch">
+        <div className="flex flex-col items-center w-full h-full min-w-0">
+          <DeviceScreen width={screenWidth} height={screenHeight} />
+          <PhysicallyButtons width={screenWidth} isRotated={isRotated} />
         </div>
-        {/* Cihaz Eylemleri sadece desktop'ta gösterilir */}
-        <div className="hidden lg:flex flex-shrink-0 min-h-[50vh] max-h-[80vh] h-full">
+        <div className="hidden lg:flex flex-shrink-0">
           <DeviceActionButtonGroup onRotate={onRotate} />
         </div>
       </div>

--- a/src/features/device/components/DeviceHeader.tsx
+++ b/src/features/device/components/DeviceHeader.tsx
@@ -1,9 +1,14 @@
 import React from "react";
+import { DeviceType } from "../../../data/deviceTypes";
 
-const DeviceHeader: React.FC = () => (
+interface DeviceHeaderProps {
+  device: DeviceType;
+}
+
+const DeviceHeader: React.FC<DeviceHeaderProps> = ({ device }) => (
   <div className="bg-indigo-200 rounded-lg min-h-[6vh] h-12 lg:h-14 w-full flex items-center px-4 lg:px-6 text-indigo-900 font-semibold text-base lg:text-lg shadow">
-    DeviceHeader
+    {device.name}
   </div>
 );
 
-export default DeviceHeader; 
+export default DeviceHeader;

--- a/src/features/device/components/DeviceScreen.tsx
+++ b/src/features/device/components/DeviceScreen.tsx
@@ -1,19 +1,17 @@
 import React from "react";
 
 interface DeviceScreenProps {
-  isRotated: boolean;
+  width: number;
+  height: number;
 }
 
-const DeviceScreen: React.FC<DeviceScreenProps> = ({ isRotated }) => (
-  <div 
-    className={`bg-green-200 rounded-lg flex items-center justify-center text-green-900 font-medium shadow w-full ${
-      isRotated 
-        ? 'aspect-[16/9] min-w-[30vw] max-w-[40vw] h-auto' 
-        : 'aspect-[9/16] min-h-[40vh] max-h-[70vh]'
-    }`}
+const DeviceScreen: React.FC<DeviceScreenProps> = ({ width, height }) => (
+  <div
+    className="bg-green-200 rounded-lg flex items-center justify-center text-green-900 font-medium shadow"
+    style={{ width, height, maxWidth: '100%', maxHeight: '80vh' }}
   >
-    DeviceScreen {isRotated ? '(Yatay)' : '(Dikey)'}
+    DeviceScreen
   </div>
 );
 
-export default DeviceScreen; 
+export default DeviceScreen;

--- a/src/features/device/components/PhysicallyButtons.tsx
+++ b/src/features/device/components/PhysicallyButtons.tsx
@@ -1,15 +1,17 @@
 import React from "react";
 
 interface PhysicallyButtonsProps {
+  width: number;
   isRotated?: boolean;
 }
 
-const PhysicallyButtons: React.FC<PhysicallyButtonsProps> = ({ isRotated = false }) => (
-  <div className={`bg-orange-200 rounded-lg w-full flex items-center justify-center text-orange-900 font-medium shadow ${
-    isRotated ? 'h-16 min-h-[6vh] max-h-[7vh]' : 'h-20 min-h-[7vh] max-h-[9vh]'
-  }`}>
+const PhysicallyButtons: React.FC<PhysicallyButtonsProps> = ({ width, isRotated = false }) => (
+  <div
+    className={`bg-orange-200 rounded-lg flex items-center justify-center text-orange-900 font-medium shadow ${isRotated ? 'h-16' : 'h-20'}`}
+    style={{ width, maxWidth: '100%' }}
+  >
     PhysicallyButtons
   </div>
 );
 
-export default PhysicallyButtons; 
+export default PhysicallyButtons;

--- a/src/features/sidebar/components/Sidebar.tsx
+++ b/src/features/sidebar/components/Sidebar.tsx
@@ -1,15 +1,26 @@
 import React from "react";
+import { DeviceType } from "../../../data/deviceTypes";
 
-const Sidebar: React.FC = () => (
-  <aside className="bg-blue-200 w-[12vw] min-w-[6vw] max-w-[9vw] lg:w-[4vw] lg:min-w-[5vw] lg:max-w-[7vw] min-h-screen sticky top-0 flex-shrink-0 flex flex-col items-center py-4 lg:py-8 px-2 lg:px-0 shadow-lg">
-    <div className="w-4/5 h-32 lg:h-56 bg-blue-400 rounded-lg flex flex-col items-center justify-center text-blue-900 font-bold text-xs lg:text-lg mb-4">
-      <div className="flex flex-col justify-center items-center">
-        {"Sidebar".split("").map((char, idx) => (
-          <span key={idx}>{char}</span>
-        ))}
-      </div>
+interface SidebarProps {
+  devices: DeviceType[];
+  selectedId: string;
+  onSelect: (id: string) => void;
+}
+
+const Sidebar: React.FC<SidebarProps> = ({ devices, selectedId, onSelect }) => (
+  <aside className="bg-blue-200 w-[12vw] min-w-[6vw] max-w-[9vw] lg:w-[4vw] lg:min-w-[5vw] lg:max-w-[7vw] min-h-screen sticky top-0 flex-shrink-0 flex flex-col items-center py-4 lg:py-8 px-2 lg:px-0 shadow-lg overflow-y-auto">
+    <div className="w-full flex flex-col gap-2">
+      {devices.map((d) => (
+        <button
+          key={d.id}
+          onClick={() => onSelect(d.id)}
+          className={`w-full text-xs lg:text-sm px-1 py-2 rounded-lg ${selectedId === d.id ? 'bg-blue-500 text-white' : 'bg-blue-400 text-blue-900'}`}
+        >
+          {d.name}
+        </button>
+      ))}
     </div>
   </aside>
 );
 
-export default Sidebar; 
+export default Sidebar;

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -3,29 +3,33 @@ import Sidebar from "../../features/sidebar/components/Sidebar";
 import DeviceDetails from "../../features/deviceDetails/components/DeviceDetails";
 import DeviceArea from "../../features/device/components/DeviceArea";
 import RightPanel from "../../features/device/components/RightPanel";
+import { deviceTypes } from "../../data/deviceTypes";
 
 const Home: React.FC = () => {
   const [isRotated, setIsRotated] = useState(false);
+  const [selectedId, setSelectedId] = useState(deviceTypes[0].id);
 
   const handleRotate = () => {
     setIsRotated(!isRotated);
   };
 
+  const handleSelectDevice = (id: string) => {
+    setSelectedId(id);
+  };
+
+  const selectedDevice = deviceTypes.find((d) => d.id === selectedId)!;
+
   return (
     <div className="min-h-screen flex flex-row bg-gray-100">
-      <Sidebar />
-      {/* Main Area (Header + Content) */}
+      <Sidebar devices={deviceTypes} selectedId={selectedId} onSelect={handleSelectDevice} />
       <div className="flex-1 flex flex-col min-w-0">
         <div className="flex-shrink-0 px-4 lg:px-8 pt-4 lg:pt-8">
           <DeviceDetails />
         </div>
-        {/* Main Content Row */}
         <main className="flex flex-col xl:flex-row gap-8 px-4 lg:px-8 pb-4 lg:pb-8 flex-1 items-stretch h-full">
-          {/* Sol Panel - Rotasyona göre hafif oransal değişim */}
           <div className={`${isRotated ? 'xl:flex-[6]' : 'xl:flex-[5]'} flex flex-col h-full`}>
-            <DeviceArea isRotated={isRotated} onRotate={handleRotate} />
+            <DeviceArea device={selectedDevice} isRotated={isRotated} onRotate={handleRotate} />
           </div>
-          {/* Right Panel - Rotasyona göre hafif oransal değişim - Sadece büyük ekranlarda */}
           <div className={`${isRotated ? 'xl:flex-[5]' : 'xl:flex-[6]'} hidden md:flex flex-col h-full`}>
             <RightPanel />
           </div>
@@ -35,4 +39,4 @@ const Home: React.FC = () => {
   );
 };
 
-export default Home; 
+export default Home;

--- a/src/utils/deviceCalculations.ts
+++ b/src/utils/deviceCalculations.ts
@@ -1,0 +1,7 @@
+export function calculateDevicePixels(diagonalInch: number, aspectRatio: number, ppi: number) {
+  const heightInch = Math.sqrt(Math.pow(diagonalInch, 2) / (Math.pow(aspectRatio, 2) + 1));
+  const widthInch = heightInch * aspectRatio;
+  const widthPx = Math.round(widthInch * ppi);
+  const heightPx = Math.round(heightInch * ppi);
+  return { widthPx, heightPx };
+}


### PR DESCRIPTION
## Summary
- add utilities to compute device pixel sizes from inch/ppi/ratio
- define sample devices with physical specs
- show available devices in the sidebar
- update device components to use real pixel sizes
- allow selecting and rotating devices on the home page

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npx tsc --noEmit` *(fails: Cannot find type definition file for 'react')*

------
https://chatgpt.com/codex/tasks/task_b_6870c0ad79a0832c8bd5bb53f9d04583