### PR TITLE
Fix dynamic button width in device simulator

### DIFF
--- a/src/features/device/components/DeviceScreen.tsx
+++ b/src/features/device/components/DeviceScreen.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import PhysicallyButtons from "./PhysicallyButtons";
+import useElementWidth from "../../../hooks/useElementWidth";
 
 interface DeviceScreenProps {
   isRotated: boolean;
@@ -12,27 +13,16 @@ const DeviceScreen: React.FC<DeviceScreenProps> = ({
   src = "/src/assets/diktel.jpg",
   onDeviceTypeChange,
 }) => {
-  const imgRef = React.useRef<HTMLImageElement>(null);
-  const [imgWidth, setImgWidth] = React.useState<number | undefined>(undefined);
+  const { ref: imgRef, width: imgWidth } = useElementWidth<HTMLImageElement>();
   const [deviceType, setDeviceType] = React.useState<"phone" | "tablet">(
     "phone"
   );
 
-  React.useEffect(() => {
-    const handleWidth = () => {
-      if (imgRef.current) {
-        setImgWidth(imgRef.current.clientWidth);
-      }
-    };
-    handleWidth();
-    window.addEventListener("resize", handleWidth);
-    return () => window.removeEventListener("resize", handleWidth);
-  }, [isRotated, src]);
+  // Width of the image is tracked via ResizeObserver in useElementWidth
 
   // Görsel yüklendiğinde oranı kontrol et
   const handleImageLoad = () => {
     if (imgRef.current) {
-      setImgWidth(imgRef.current.clientWidth);
       const img = imgRef.current;
       const ratio = img.naturalWidth / img.naturalHeight;
       let type: "phone" | "tablet" = "phone";

--- a/src/hooks/useElementWidth.ts
+++ b/src/hooks/useElementWidth.ts
@@ -1,0 +1,28 @@
+import { useEffect, useRef, useState } from "react";
+
+export default function useElementWidth<T extends HTMLElement>() {
+  const ref = useRef<T>(null);
+  const [width, setWidth] = useState<number>();
+
+  useEffect(() => {
+    const element = ref.current;
+    if (!element) return;
+
+    const handleResize = (entries: ResizeObserverEntry[]) => {
+      const entry = entries[0];
+      if (entry) {
+        setWidth(entry.contentRect.width);
+      }
+    };
+
+    const observer = new ResizeObserver(handleResize);
+    observer.observe(element);
+
+    // Initialize width immediately
+    setWidth(element.clientWidth);
+
+    return () => observer.disconnect();
+  }, []);
+
+  return { ref, width };
+}


### PR DESCRIPTION
## Summary
- add a `useElementWidth` hook to track element width with ResizeObserver
- use the hook in `DeviceScreen` to sync the physical button width with the screen

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_b_6873b9f53410832ca4891cd63dfa11d7