### PR TITLE
Fix rotated device screen spacing

### DIFF
--- a/src/features/device/components/DeviceScreen.tsx
+++ b/src/features/device/components/DeviceScreen.tsx
@@ -16,12 +16,14 @@ const DeviceScreen: React.FC<DeviceScreenProps> = ({
   const [deviceType, setDeviceType] = React.useState<"phone" | "tablet">(
     "phone"
   );
+  const [imageSize, setImageSize] = React.useState<{ width: number; height: number } | null>(null);
 
   // Görsel yüklendiğinde oranı kontrol et
   const handleImageLoad = () => {
     if (imgRef.current) {
       const img = imgRef.current;
       const ratio = img.naturalWidth / img.naturalHeight;
+      setImageSize({ width: img.naturalWidth, height: img.naturalHeight });
       let type: "phone" | "tablet" = "phone";
       // Eğer src'de 'diktel' geçiyorsa tablet olarak işaretle
       if (src && src.toLowerCase().includes("diktel")) {
@@ -40,9 +42,13 @@ const DeviceScreen: React.FC<DeviceScreenProps> = ({
     }
   };
 
-  // Aspect-ratio'yu cihaz tipine ve rotasyona göre ayarla
+  // Aspect-ratio'yu görsel boyutlarına ve rotasyona göre ayarla
   let aspectRatio;
-  if (deviceType === "tablet") {
+  if (imageSize) {
+    aspectRatio = isRotated
+      ? `${imageSize.height}/${imageSize.width}`
+      : `${imageSize.width}/${imageSize.height}`;
+  } else if (deviceType === "tablet") {
     aspectRatio = isRotated ? "16/9" : "4/3";
   } else {
     aspectRatio = isRotated ? "10/9" : "9/16";

--- a/src/features/device/components/DeviceScreen.tsx
+++ b/src/features/device/components/DeviceScreen.tsx
@@ -64,7 +64,7 @@ const DeviceScreen: React.FC<DeviceScreenProps> = ({
         ref={imgRef}
         src={src}
         alt="Telefon"
-        className={`object-contain rounded-lg transition-transform duration-300 ${deviceType === 'tablet' && isRotated ? 'w-full h-full' : 'max-w-full max-h-full'} ${
+        className={`block object-contain rounded-lg transition-transform duration-300 ${deviceType === 'tablet' && isRotated ? 'w-full h-full' : 'max-w-full max-h-full'} ${
           isRotated ? "rotate-90" : ""
         }`}
         style={{ aspectRatio }}


### PR DESCRIPTION
## Summary
- remove gap between image and buttons when rotating screen

## Testing
- `npm run lint` *(fails: cannot find '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_b_68740df931e4832c9bf73c4b171fd1c1